### PR TITLE
Room ressource odoo

### DIFF
--- a/code/odoo/custom_addons/Abilium_Room_Booker/__manifest__.py
+++ b/code/odoo/custom_addons/Abilium_Room_Booker/__manifest__.py
@@ -12,6 +12,8 @@
     'depends': [
         'base',
         'calendar',
+        'contacts', # for res.partner -> displaying rooms in calendar
+        'resource', # for declaring as a resource
     ],
     'images': ['static/description/icon.png'],
     'data': [

--- a/code/odoo/custom_addons/Abilium_Room_Booker/models/__init__.py
+++ b/code/odoo/custom_addons/Abilium_Room_Booker/models/__init__.py
@@ -1,1 +1,1 @@
-from . import raspbi_connection, calendar_event
+from . import raspbi_connection, calendar_event, partner_extension

--- a/code/odoo/custom_addons/Abilium_Room_Booker/models/calendar_event.py
+++ b/code/odoo/custom_addons/Abilium_Room_Booker/models/calendar_event.py
@@ -7,6 +7,6 @@ class CalendarEvent(models.Model):
     meeting_room = fields.Many2one(
         'rasproom.connection', 
         string="Choose Meeting Room", 
-        required=True,
+        required=False,
         domain=[('status', '=', True)]  # Ensure only available rooms are shown
     )

--- a/code/odoo/custom_addons/Abilium_Room_Booker/models/partner_extension.py
+++ b/code/odoo/custom_addons/Abilium_Room_Booker/models/partner_extension.py
@@ -1,0 +1,6 @@
+from odoo import models, fields
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    resource_calendar_id = fields.Many2one('resource.calendar', string="Working Hours")

--- a/code/odoo/custom_addons/Abilium_Room_Booker/security/ir.model.access.csv
+++ b/code/odoo/custom_addons/Abilium_Room_Booker/security/ir.model.access.csv
@@ -1,4 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_rasproom_connection,Access Raspberry Connections,model_rasproom_connection,base.group_user,1,1,1,1
 access_calendar_event_custom,access.calendar.event.custom,model_calendar_event,base.group_user,1,1,1,1
+access_resource_resource_manager,access.resource.resource.manager,resource.model_resource_resource,base.group_user,1,1,1,1
+
 


### PR DESCRIPTION
Added the Res.partner and defined rooms as resource however currently there are duplicate selection methods for Rooms (seperate field and as attendee) and i don't know where exactly the res.partner can be changed for availability and disallowing duplicate planning
Possible solution to duplicate selection: delete calendar_event changes -> only the attendee selection remains

TODO! customize res.Partner